### PR TITLE
Use netflix.com instead of beta.netflix.com.

### DIFF
--- a/firefox_media_tests/urls/netflix/default.ini
+++ b/firefox_media_tests/urls/netflix/default.ini
@@ -1,8 +1,8 @@
 # YouTube test
 [https://www.youtube.com/watch?v=AbAACm1IQE0]
 # ClearKey - 11:07
-[http://www.beta.netflix.com/WiPlayer?movieid=70136810]
+[http://www.netflix.com/WiPlayer?movieid=70136810]
 # NoDRM - 2:24:xx
-[http://www.beta.netflix.com/WiPlayer?movieid=70304192]
+[http://www.netflix.com/WiPlayer?movieid=70304192]
 # DRM - 24:47
-[http://www.beta.netflix.com/WiPlayer?movieid=80015538&trkid=3329911]
+[http://www.netflix.com/WiPlayer?movieid=80015538&trkid=3329911]


### PR DESCRIPTION
Use www.netflix.com instead of www.beta.netflix.com.

@mjzffr , please review.
