### PR TITLE
Use sensible error messages if video does not start.

### DIFF
--- a/firefox_media_tests/playback/test_video_playback.py
+++ b/firefox_media_tests/playback/test_video_playback.py
@@ -53,10 +53,5 @@ class TestVideoPlaybackBase(MediaTestCase):
                     start_time = video.current_time
                     verbose_until(Wait(video, interval=1, timeout=duration),
                                   video, playback_done)
-                except TimeoutException:
-                    # We want to make sure that the current time is near the
-                    # duration we want.
-                    if video.current_time < (start_time + duration):
-                        raise
                 except VideoException as e:
-                    raise self.failureException(e.__str__())
+                    raise self.failureException(e)


### PR DESCRIPTION
When there is a problem playing video, particularly with timeout starting the video, need to be more intelligent about displaying what went wrong.
