### PR TITLE
Bug 1188103: Do a better job detecting stalls without calling Firefox

### DIFF
--- a/firefox_media_tests/utils.py
+++ b/firefox_media_tests/utils.py
@@ -36,7 +36,9 @@ def verbose_until(wait, target, condition):
 
 
 def save_memory_report(marionette):
-    """ Saves memory report (like about:memory) to current working directory."""
+    """
+    Saves memory report (like about:memory) to current working directory.
+    """
     with marionette.using_context('chrome'):
         marionette.execute_async_script("""
             Components.utils.import("resource://gre/modules/Services.jsm");


### PR DESCRIPTION
Bug 1183513: Do a better job detecting stalls without calling Firefox internal data structures. Restructure partial playback to be cleaner.

@mjzffr , please review.
