### PR TITLE
Bug 1189466: Move run_playback into MediaTestCase so that tests can be separated easily.

### DIFF
--- a/firefox_media_tests/playback/test_video_playback.py
+++ b/firefox_media_tests/playback/test_video_playback.py
@@ -8,26 +8,19 @@ from marionette_driver.errors import TimeoutException
 
 from firefox_media_tests.utils import verbose_until
 from media_test_harness.testcase import MediaTestCase
-from media_utils.video_puppeteer import (playback_done, playback_started,
-                                         VideoPuppeteer, VideoException)
+from media_utils.video_puppeteer import (playback_started, VideoPuppeteer)
 
 
-class TestVideoPlaybackBase(MediaTestCase):
+class TestVideoPlayback(MediaTestCase):
     """ Test MSE playback in HTML5 video element.
 
     These tests should pass on any site where a single video element plays
     upon loading and is uninterrupted (by ads, for example)
     """
-    def setUp(self):
-        MediaTestCase.setUp(self)
-        self.test_urls = self.video_urls
-
-    def tearDown(self):
-        MediaTestCase.tearDown(self)
 
     def test_playback_starts(self):
         with self.marionette.using_context('content'):
-            for url in self.test_urls:
+            for url in self.video_urls:
                 self.logger.info(url)
                 video = VideoPuppeteer(self.marionette, url)
 
@@ -48,23 +41,3 @@ class TestVideoPlaybackBase(MediaTestCase):
 
     def test_video_playback_full(self):
         self.run_playback()
-
-    def run_playback(self, interval=1, set_duration=None,
-                     stall_wait_time=10):
-        with self.marionette.using_context('content'):
-            for url in self.test_urls:
-                self.logger.info(url)
-                video = VideoPuppeteer(self.marionette, url,
-                                       interval=interval,
-                                       set_duration=set_duration,
-                                       stall_wait_time=stall_wait_time)
-                verbose_until(Wait(video, timeout=30), video,
-                              playback_started)
-
-                try:
-                    verbose_until(Wait(video, interval=interval,
-                                       timeout=video.duration * 1.3
-                                       + stall_wait_time),
-                                  video, playback_done)
-                except VideoException as e:
-                    raise self.failureException(e)

--- a/media_test_harness/testcase.py
+++ b/media_test_harness/testcase.py
@@ -4,12 +4,19 @@
 
 import os
 
+from marionette_driver import Wait
+
 from firefox_ui_harness import FirefoxTestCase
-from firefox_media_tests.utils import timestamp_now
-from media_utils.video_puppeteer import VideoPuppeteer as VP
+from firefox_media_tests.utils import (timestamp_now, verbose_until)
+from media_utils.video_puppeteer import (playback_done, playback_started,
+                                         VideoException, VideoPuppeteer as VP)
 
 
 class MediaTestCase(FirefoxTestCase):
+
+    def __init__(self, *args, **kwargs):
+        self.video_urls = kwargs.pop('video_urls', False)
+        FirefoxTestCase.__init__(self, *args, **kwargs)
 
     @property
     def failureException(self):
@@ -39,6 +46,21 @@ class MediaTestCase(FirefoxTestCase):
             if debug_lines:
                 self.marionette.log('\n'.join(debug_lines))
 
-    def __init__(self, *args, **kwargs):
-        self.video_urls = kwargs.pop('video_urls', False)
-        FirefoxTestCase.__init__(self, *args, **kwargs)
+    def run_playback(self, interval=1, set_duration=None,
+                     stall_wait_time=10):
+        with self.marionette.using_context('content'):
+            for url in self.video_urls:
+                self.logger.info(url)
+                video = VP(self.marionette, url, interval=interval,
+                           set_duration=set_duration,
+                           stall_wait_time=stall_wait_time)
+                verbose_until(Wait(video, timeout=30), video,
+                              playback_started)
+
+                try:
+                    verbose_until(Wait(video, interval=interval,
+                                       timeout=video.duration * 1.3
+                                       + stall_wait_time),
+                                  video, playback_done)
+                except VideoException as e:
+                    raise self.failureException(e)


### PR DESCRIPTION
This is the first patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1189466.
