### PR TITLE
Bug 1189466 - Separate partial and full playback

### DIFF
--- a/firefox_media_tests/playback/test_full_playback.py
+++ b/firefox_media_tests/playback/test_full_playback.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from media_test_harness.testcase import MediaTestCase
+
+
+class TestFullPlayback(MediaTestCase):
+    """ Test MSE playback in HTML5 video element.
+
+    These tests should pass on any site where a single video element plays
+    upon loading and is uninterrupted (by ads, for example). This will play
+    the full videos, so it could take a while depending on the videos playing.
+    It should be run much less frequently in automated systems.
+    """
+
+    def test_video_playback_full(self):
+        self.run_playback()

--- a/firefox_media_tests/playback/test_video_playback.py
+++ b/firefox_media_tests/playback/test_video_playback.py
@@ -15,7 +15,10 @@ class TestVideoPlayback(MediaTestCase):
     """ Test MSE playback in HTML5 video element.
 
     These tests should pass on any site where a single video element plays
-    upon loading and is uninterrupted (by ads, for example)
+    upon loading and is uninterrupted (by ads, for example).
+
+    This test both starting videos and performing partial playback at one
+    minute each, and is the test that should be run frequently in automation.
     """
 
     def test_playback_starts(self):
@@ -38,6 +41,3 @@ class TestVideoPlayback(MediaTestCase):
 
     def test_video_playback_partial(self):
         self.run_playback(set_duration=60)
-
-    def test_video_playback_full(self):
-        self.run_playback()


### PR DESCRIPTION
The tests for partial playback, full playback,and starting playback need to be separated. Actually, I left playback
startup and partial playback together. Move the full playback to its own
test file.
