### PR TITLE
Bug 1197948 - Determine expected video duration

### DIFF
--- a/firefox_media_tests/playback/test_full_playback.py
+++ b/firefox_media_tests/playback/test_full_playback.py
@@ -4,6 +4,7 @@
 
 
 from media_test_harness.testcase import MediaTestCase
+from media_utils.video_puppeteer import VideoPuppeteer
 
 
 class TestFullPlayback(MediaTestCase):
@@ -16,4 +17,8 @@ class TestFullPlayback(MediaTestCase):
     """
 
     def test_video_playback_full(self):
-        self.run_playback()
+        with self.marionette.using_context('content'):
+            for url in self.video_urls:
+                video = VideoPuppeteer(self.marionette, url,
+                                       stall_wait_time=10)
+                self.run_playback(video)

--- a/firefox_media_tests/playback/test_video_playback.py
+++ b/firefox_media_tests/playback/test_video_playback.py
@@ -2,13 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
-from marionette_driver import Wait
 from marionette_driver.errors import TimeoutException
 
-from firefox_media_tests.utils import verbose_until
 from media_test_harness.testcase import MediaTestCase
-from media_utils.video_puppeteer import (playback_started, VideoPuppeteer)
+from media_utils.video_puppeteer import VideoPuppeteer
 
 
 class TestVideoPlayback(MediaTestCase):
@@ -24,20 +21,25 @@ class TestVideoPlayback(MediaTestCase):
     def test_playback_starts(self):
         with self.marionette.using_context('content'):
             for url in self.video_urls:
-                self.logger.info(url)
-                video = VideoPuppeteer(self.marionette, url)
-
                 try:
-                    verbose_until(Wait(video, timeout=30), video,
-                                  playback_started)
+                    video = VideoPuppeteer(self.marionette, url, timeout=60)
+                    # Second playback_started check in case video._start_time
+                    # is not 0
+                    self.check_playback_starts(video)
+                    video.pause()
+                    src = video.video_src
+                    if not src.startswith('mediasource'):
+                        self.marionette.log('video is not '
+                                            'mediasource: %s' % src,
+                                            level='WARNING')
                 except TimeoutException as e:
                     raise self.failureException(e)
 
-                video.pause()
-                src = video.video_src
-                if not src.startswith('mediasource'):
-                    self.marionette.log('video is not mediasource: %s' % src,
-                                        level='WARNING')
-
     def test_video_playback_partial(self):
-        self.run_playback(set_duration=60)
+        """ First 60 seconds of video play well. """
+        with self.marionette.using_context('content'):
+            for url in self.video_urls:
+                video = VideoPuppeteer(self.marionette, url,
+                                       stall_wait_time=10,
+                                       set_duration=60)
+                self.run_playback(video)

--- a/firefox_media_tests/playback/youtube/test_basic_playback.py
+++ b/firefox_media_tests/playback/youtube/test_basic_playback.py
@@ -9,28 +9,16 @@ from firefox_media_tests.utils import verbose_until
 from media_test_harness.testcase import MediaTestCase
 from media_utils.video_puppeteer import VideoException
 from media_utils.youtube_puppeteer import (YouTubePuppeteer, playback_done,
-                                           playback_started,
                                            wait_for_almost_done)
 
 
 class TestBasicYouTubePlayback(MediaTestCase):
-
-    def setUp(self):
-        MediaTestCase.setUp(self)
-        self.test_urls = self.video_urls
-
-    def tearDown(self):
-        MediaTestCase.tearDown(self)
-
     def test_mse_is_enabled_by_default(self):
-        # Why wait to check src until initial ad is done playing?
-        # - src attribute in video element is sometimes null during ad playback
-        # - many ads still don't use MSE even if main video does
         with self.marionette.using_context('content'):
-            youtube = YouTubePuppeteer(self.marionette, self.test_urls[0])
-            youtube.attempt_ad_skip()
+            youtube = YouTubePuppeteer(self.marionette, self.video_urls[0],
+                                       timeout=60)
             wait = Wait(youtube,
-                        timeout=min(300, youtube.player_duration * 1.3),
+                        timeout=min(300, youtube.expected_duration * 1.3),
                         interval=1)
             try:
                 verbose_until(wait, youtube,
@@ -40,22 +28,23 @@ class TestBasicYouTubePlayback(MediaTestCase):
 
     def test_video_playing_in_one_tab(self):
         with self.marionette.using_context('content'):
-            for url in self.test_urls:
+            for url in self.video_urls:
                 self.logger.info(url)
                 youtube = YouTubePuppeteer(self.marionette, url)
+                self.logger.info('Expected duration: %s' %
+                                 youtube.expected_duration)
                 youtube.deactivate_autoplay()
+
                 final_piece = 60
                 try:
                     time_left = wait_for_almost_done(youtube,
                                                      final_piece=final_piece)
                 except VideoException as e:
                     raise self.failureException(e)
-                duration = abs(youtube.player_duration) + 1
+                duration = abs(youtube.expected_duration) + 1
                 if duration > 1:
-                    self.marionette.log('Almost done: '
-                                        '%s - %s seconds left.' %
-                                        (youtube.movie_id,
-                                         time_left))
+                    self.logger.info('Almost done: %s - %s seconds left.' %
+                                     (youtube.movie_id, time_left))
                     if time_left > final_piece:
                         self.marionette.log('time_left greater than '
                                             'final_piece - %s' % time_left,
@@ -76,10 +65,8 @@ class TestBasicYouTubePlayback(MediaTestCase):
 
     def test_playback_starts(self):
         with self.marionette.using_context('content'):
-            for url in self.test_urls:
-                youtube = YouTubePuppeteer(self.marionette, url)
+            for url in self.video_urls:
                 try:
-                    verbose_until(Wait(youtube, timeout=60, interval=1),
-                                  youtube, playback_started)
+                    YouTubePuppeteer(self.marionette, url, timeout=60)
                 except TimeoutException as e:
                     raise self.failureException(e)


### PR DESCRIPTION
- To get an accurate expected duration:
  - Wait for video to start in VideoPuppeteer constructor
    - This in turn affects how playback_started tests are written
  - Wait for/skip initial ads in YouTubePuppeteer constructor
  - Update conditions for ad-detection in reponse to changes in YouTube
    JS API
- Refactoring
  - Move loop out of MediaTestCase.run_playback
  - Differentiate between duration and expected_duration in
    VideoPuppeteer

The details:
- Check for that playback starts in puppeteer constructor because most accurate `expected_duration` is obtained once video is fully loaded and started
  - Therefore, update `playback_started` tests to just call the puppeteer constructor
- Moved `set_duration`/`_calculated_duration` logic to `expected_duration`, so that `self.duration` is always whatever video element tells us
- Moved loop out of `run_playback` so we don't always have to run all videos
- removed params from `run_playback` since they're all in `video` anyway; just
  pass in `video`
- set default value of `stall_wait_time` and `set_duration` to 0 to avoid 
  run_time errors when we're not using them (e.g. in youtube tests)
- changed conditions for some ad-skipping things
  - it is no longer true that `current_time` stands still while an ad is playing
  - some things in youtube API seem to have changed and are more reliable (like `ad_playing`)
- move initial ad_skipping into YouTubePuppeteer init, to get best chance at getting an accurate expected_duration throughout a test
