### PR TITLE
Bug 1207324: Handle EME prefs for Netflix

### DIFF
--- a/firefox_media_tests/playback/eme.ini
+++ b/firefox_media_tests/playback/eme.ini
@@ -1,0 +1,1 @@
+[test_eme_playback.py]

--- a/firefox_media_tests/playback/test_eme_playback.py
+++ b/firefox_media_tests/playback/test_eme_playback.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+from media_test_harness.testcase import MediaTestCase, VideoPlaybackTestsMixin
+
+
+class TestEMEPlayback(MediaTestCase, VideoPlaybackTestsMixin):
+
+    def setUp(self):
+        super(TestEMEPlayback, self).setUp()
+        self.set_eme_prefs()
+        assert(self.check_eme_prefs())
+
+    def set_eme_prefs(self):
+        with self.marionette.using_context('chrome'):
+
+            # https://bugzilla.mozilla.org/show_bug.cgi?id=1187471#c28
+            # 2015-09-28 cpearce says this is no longer necessary, but in case
+            # we are working with older firefoxes...
+            self.prefs.set_pref('media.gmp.trial-create.enabled', False)
+
+    def check_and_log_boolean_pref(self, pref_name, expected_value):
+        with self.marionette.using_context('chrome'):
+            pref_value = self.prefs.get_pref(pref_name)
+
+            if pref_value is None:
+                self.logger.info('Pref %s has no value.' % pref_name)
+                return False
+            else:
+                self.logger.info('Pref %s = %s' % (pref_name, pref_value))
+                if pref_value != expected_value:
+                    self.logger.info('Pref %s has unexpected value.'
+                                     % pref_name)
+                    return False
+
+        return True
+
+    def check_and_log_integer_pref(self, pref_name, minimum_value=0):
+        with self.marionette.using_context('chrome'):
+            pref_value = self.prefs.get_pref(pref_name)
+
+            if pref_value is None:
+                self.logger.info('Pref %s has no value.' % pref_name)
+                return False
+            else:
+                self.logger.info('Pref %s = %s' % (pref_name, pref_value))
+
+                match = re.search('^\d+$', pref_value)
+                if not match:
+                    self.logger.info('Pref %s is not an integer' % pref_name)
+                    return False
+
+            return pref_value >= minimum_value
+
+    def check_eme_prefs(self):
+        with self.marionette.using_context('chrome'):
+            prefs_ok = self.check_and_log_boolean_pref(
+                'media.mediasource.enabled', True)
+            prefs_ok = self.check_and_log_boolean_pref(
+                'media.eme.enabled', True) and prefs_ok
+            prefs_ok = self.check_and_log_boolean_pref(
+                'media.mediasource.mp4.enabled', True) and prefs_ok
+            prefs_ok = self.check_and_log_boolean_pref(
+                'media.gmp-eme-adobe.enabled', True) and prefs_ok
+            prefs_ok = self.check_and_log_integer_pref(
+                'media.gmp-eme-adobe.version', 1) and prefs_ok
+
+        return prefs_ok

--- a/firefox_media_tests/playback/test_video_playback.py
+++ b/firefox_media_tests/playback/test_video_playback.py
@@ -2,44 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from marionette_driver.errors import TimeoutException
+from media_test_harness.testcase import (
+    MediaTestCase,
+    VideoPlaybackTestsMixin
+)
 
-from media_test_harness.testcase import MediaTestCase
-from media_utils.video_puppeteer import VideoPuppeteer
 
+class TestVideoPlayback(MediaTestCase, VideoPlaybackTestsMixin):
 
-class TestVideoPlayback(MediaTestCase):
-    """ Test MSE playback in HTML5 video element.
+    # Tests are actually implemented in VideoPlaybackTestsMixin.
 
-    These tests should pass on any site where a single video element plays
-    upon loading and is uninterrupted (by ads, for example).
-
-    This test both starting videos and performing partial playback at one
-    minute each, and is the test that should be run frequently in automation.
-    """
-
-    def test_playback_starts(self):
-        with self.marionette.using_context('content'):
-            for url in self.video_urls:
-                try:
-                    video = VideoPuppeteer(self.marionette, url, timeout=60)
-                    # Second playback_started check in case video._start_time
-                    # is not 0
-                    self.check_playback_starts(video)
-                    video.pause()
-                    src = video.video_src
-                    if not src.startswith('mediasource'):
-                        self.marionette.log('video is not '
-                                            'mediasource: %s' % src,
-                                            level='WARNING')
-                except TimeoutException as e:
-                    raise self.failureException(e)
-
-    def test_video_playback_partial(self):
-        """ First 60 seconds of video play well. """
-        with self.marionette.using_context('content'):
-            for url in self.video_urls:
-                video = VideoPuppeteer(self.marionette, url,
-                                       stall_wait_time=10,
-                                       set_duration=60)
-                self.run_playback(video)
+    pass

--- a/media_test_harness/testcase.py
+++ b/media_test_harness/testcase.py
@@ -66,3 +66,41 @@ class MediaTestCase(FirefoxTestCase):
         gets recognized a skip in marionette.marionette_test.CommonTestCase.run
         """
         raise SkipTest(reason)
+
+
+class VideoPlaybackTestsMixin(object):
+
+    """ Test MSE playback in HTML5 video element.
+
+    These tests should pass on any site where a single video element plays
+    upon loading and is uninterrupted (by ads, for example).
+
+    This test both starting videos and performing partial playback at one
+    minute each, and is the test that should be run frequently in automation.
+    """
+
+    def test_playback_starts(self):
+        with self.marionette.using_context('content'):
+            for url in self.video_urls:
+                try:
+                    video = VP(self.marionette, url, timeout=60)
+                    # Second playback_started check in case video._start_time
+                    # is not 0
+                    self.check_playback_starts(video)
+                    video.pause()
+                    src = video.video_src
+                    if not src.startswith('mediasource'):
+                        self.marionette.log('video is not '
+                                            'mediasource: %s' % src,
+                                            level='WARNING')
+                except TimeoutException as e:
+                    raise self.failureException(e)
+
+    def test_video_playback_partial(self):
+        """ First 60 seconds of video play well. """
+        with self.marionette.using_context('content'):
+            for url in self.video_urls:
+                video = VP(self.marionette, url,
+                           stall_wait_time=10,
+                           set_duration=60)
+                self.run_playback(video)


### PR DESCRIPTION
Set media.gmp.trial-create.enabled so that Silverlight is not prompted. Check MSE and EME prefs before running tests. Refactor basic video tests.
