### PR TITLE
Bug 1237774 - Update requirements to use firefox-puppeteer 3.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ mozdevice==0.46
 mozfile==1.2
 mozhttpd==0.7
 mozinfo==0.8
+# optional - mozharness install step
 mozInstall==1.12
 mozlog==3.0
 moznetwork==0.27
@@ -15,7 +16,7 @@ moztest==0.7
 mozversion==1.4
 marionette-client == 2.0.0
 marionette-driver == 1.1.1
-firefox_puppeteer==3.0.0
+firefox-puppeteer==3.1.0
 
 # Install the firefox media tests package
 ./

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = [
     'marionette-driver == 1.1.1',
     'mozlog == 3.0',
     'manifestparser == 1.1',
-    'firefox_puppeteer == 3.0.0',
+    'firefox-puppeteer >= 3.1.0, <4.0.0',
 ]
 
 setup(name='firefox-media-tests',


### PR DESCRIPTION
Successful run: http://pf-jenkins.qa.mtv2.mozilla.com:8080/view/temp/job/temp_test-mn-mse-youtube-basic-y-nightly-mac/72/console
